### PR TITLE
Convert bot to slash commands and add interactive Rock-Paper-Scissors game

### DIFF
--- a/discord_bot/README.md
+++ b/discord_bot/README.md
@@ -6,8 +6,9 @@ This is a simple Discord bot built with Python using the discord.py library.
 
 - Greets new members when they join the server.
 - Responds with "Hi!, {pinger}" when pinged (mentioned) in a message.
-- **!reboot**: Restarts the bot (Administrator only).
-- **!shutdown**: Gracefully shuts down the bot (Administrator only).
+- **/reboot**: Restarts the bot (Administrator only).
+- **/shutdown**: Gracefully shuts down the bot (Administrator only).
+- **/games**: Play Rock-Paper-Scissors with the bot.
 
 ## Setup
 

--- a/discord_bot/bot.py
+++ b/discord_bot/bot.py
@@ -1,7 +1,8 @@
 import discord
-from discord.ext import commands
+from discord import app_commands
 import os
 import sys
+import random
 from dotenv import load_dotenv
 
 # Load environment variables from .env file
@@ -10,12 +11,18 @@ load_dotenv()
 # Get the bot token from environment variables
 TOKEN = os.getenv('DISCORD_BOT_TOKEN')
 
-# Create a bot instance with a command prefix
-bot = commands.Bot(command_prefix='!', intents=discord.Intents.all())
+# Create a bot instance with intents
+intents = discord.Intents.default()
+intents.members = True
+intents.message_content = True
+bot = discord.Client(intents=intents)
+tree = app_commands.CommandTree(bot)
 
 @bot.event
 async def on_ready():
     print(f'Bot is ready. Logged in as {bot.user}')
+    # Sync the command tree
+    await tree.sync()
 
 @bot.event
 async def on_member_join(member):
@@ -34,22 +41,46 @@ async def on_message(message):
     if bot.user in message.mentions:
         await message.channel.send(f'Hi!, {message.author.mention}')
 
-    # Process commands
-    await bot.process_commands(message)
-
-@bot.command()
-@commands.has_permissions(administrator=True)
-async def reboot(ctx):
-    """Reboot the bot (Admin only)"""
-    await ctx.send("🔄 Rebooting...")
+@tree.command(name="reboot", description="Reboot the bot (Admin only)")
+@app_commands.checks.has_permissions(administrator=True)
+async def reboot(interaction: discord.Interaction):
+    await interaction.response.send_message("🔄 Rebooting...")
     os.execv(sys.executable, [sys.executable] + sys.argv)
 
-@bot.command()
-@commands.has_permissions(administrator=True)
-async def shutdown(ctx):
-    """Shutdown the bot (Admin only)"""
-    await ctx.send("🛑 Shutting down...")
+@tree.command(name="shutdown", description="Shutdown the bot (Admin only)")
+@app_commands.checks.has_permissions(administrator=True)
+async def shutdown(interaction: discord.Interaction):
+    await interaction.response.send_message("🛑 Shutting down...")
     await bot.close()
+
+@tree.command(name="games", description="Play Rock-Paper-Scissors with the bot")
+@app_commands.describe(choice="Choose your move")
+@app_commands.choices(choice=[
+    app_commands.Choice(name="Rock", value="rock"),
+    app_commands.Choice(name="Paper", value="paper"),
+    app_commands.Choice(name="Scissors", value="scissors")
+])
+async def games(interaction: discord.Interaction, choice: str):
+    user_choice = choice.lower()
+    bot_choice = random.choice(["rock", "paper", "scissors"])
+
+    # Determine the winner
+    if user_choice == bot_choice:
+        result = "It's a tie! 🤝"
+    elif (user_choice == "rock" and bot_choice == "scissors") or \
+         (user_choice == "paper" and bot_choice == "rock") or \
+         (user_choice == "scissors" and bot_choice == "paper"):
+        result = "You win! 🎉"
+    else:
+        result = "I win! 😎"
+
+    # Create emoji representations
+    emoji_map = {"rock": "🪨", "paper": "📄", "scissors": "✂️"}
+    user_emoji = emoji_map.get(user_choice, user_choice)
+    bot_emoji = emoji_map.get(bot_choice, bot_choice)
+
+    response = f"You chose {user_emoji} {user_choice.capitalize()}\nI chose {bot_emoji} {bot_choice.capitalize()}\n\n{result}"
+    await interaction.response.send_message(response)
 
 # Run the bot
 bot.run(TOKEN)


### PR DESCRIPTION
This PR converts the Discord bot to use slash commands and adds an interactive Rock-Paper-Scissors game with /games command. It also includes admin commands /reboot and /shutdown as slash commands.