### PR TITLE
Fix slash commands registration for immediate availability

### DIFF
--- a/discord_bot/README.md
+++ b/discord_bot/README.md
@@ -10,6 +10,10 @@ This is a simple Discord bot built with Python using the discord.py library.
 - **/shutdown**: Gracefully shuts down the bot (Administrator only).
 - **/games**: Play Rock-Paper-Scissors with the bot.
 
+## Slash Commands
+
+The bot uses slash commands that are registered to your specific Discord server for faster availability. Commands should appear immediately after the bot starts.
+
 ## Setup
 
 1. Make sure you have Python installed (version 3.8 or higher recommended).

--- a/discord_bot/bot.py
+++ b/discord_bot/bot.py
@@ -18,11 +18,16 @@ intents.message_content = True
 bot = discord.Client(intents=intents)
 tree = app_commands.CommandTree(bot)
 
+# Guild ID for faster command registration
+GUILD_ID = 1411714476113133680
+
 @bot.event
 async def on_ready():
     print(f'Bot is ready. Logged in as {bot.user}')
-    # Sync the command tree
-    await tree.sync()
+    # Sync the command tree to the specific guild for faster availability
+    guild = discord.Object(id=GUILD_ID)
+    await tree.sync(guild=guild)
+    print(f'Commands synced to guild {GUILD_ID}')
 
 @bot.event
 async def on_member_join(member):


### PR DESCRIPTION
This PR fixes the issue where slash commands weren't appearing by registering them to the specific Discord guild instead of globally. This ensures commands are available immediately after the bot starts. Changes include: - Added guild ID for command registration - Modified command sync to target specific guild - Updated README with slash command information